### PR TITLE
Move blog into its own page

### DIFF
--- a/content/blog.md
+++ b/content/blog.md
@@ -1,0 +1,37 @@
+---
+title: "Blog"
+---
+
+
+## Technical overview
+
+* Apr 2020: [Things I Wished More Developers Knew About Databases](https://medium.com/@rakyll/things-i-wished-more-developers-knew-about-databases-2d0178464f78)
+
+## Operational excellence
+
+* Jul 2020: [Cloud Spanner Change Watcher](https://medium.com/@knutolavloite/cloud-spanner-change-watcher-b77ca036459c) and [Cloud Spanner Change Publisher](https://medium.com/@knutolavloite/cloud-spanner-change-publisher-7fbee48f66f8)
+* May 2020: [Create Cloud Spanner Scheduled Backups](https://medium.com/@hengfeng/create-cloud-spanner-scheduled-backups-c6f30551a6fd)
+* Apr 2020: [Instrumenting Cloud Spanner Go Applications with OpenCensus](https://medium.com/google-cloud/instrumenting-cloud-spanner-go-applications-with-opencensus-6e734eb4d8c8)
+* Mar 2020: [Troubleshooting Cloud Spanner Applications with OpenCensus](https://medium.com/@mayurkale22/troubleshooting-cloud-spanner-applications-with-opencensus-2cf424c4c590)
+
+## Internals
+
+* May 2020: [How Does Spanner Avoid Single Point of Failures in Writes?](https://medium.com/google-cloud/how-does-spanner-avoid-single-point-of-failures-in-writes-4f7765cd894)
+* Feb 2020: [Internals of Google Cloud Spanner](https://medium.com/searce/internals-of-google-cloud-spanner-5927e4b83b36)
+
+## Performance
+
+* Jun 2020: [Increase visibility into Cloud Spanner performance with transaction stats](https://cloud.google.com/blog/products/databases/database-transaction-stats-in-spanner)
+* May 2020: [Use GFE Server-Timing Header in Cloud Spanner Debugging](https://medium.com/google-cloud/use-gfe-server-timing-header-in-cloud-spanner-debugging-d7d891a50642)
+
+## Developer productivity
+
+* Jun 2020: [DML and Mutations - a tale of two data altering techniques in Cloud Spanner](https://medium.com/google-cloud/dml-and-mutations-a-tale-of-two-data-altering-techniques-in-cloud-spanner-df13c49f2617)
+* Apr 2020: [Cloud Spanner Emulator](https://medium.com/google-cloud/cloud-spanner-emulator-bf12d141c12)
+* Dec 2019: [Google Cloud Spanner Dialect for Hibernate released](https://in.relation.to/2019/12/18/google-cloud-spanner-dialect/)
+* Nov 2019: [Opening the door to more dev tools for Cloud Spanner](https://cloud.google.com/blog/products/databases/opening-the-door-to-more-dev-tools-for-cloud-spanner)
+
+## Migration
+
+* Feb 2020: [HarbourBridge: From PostgreSQL to Cloud Spanner](https://opensource.googleblog.com/2020/02/harbourbridge-from-postgresql-to-cloud.html)
+* Jun 2019: [Migrating from DynamoDB to Google Cloud Spanner](https://medium.com/petabytz/database-migration-migrating-from-dynamodb-to-google-cloud-spanner-part-1-ab6b8828580d)

--- a/content/resources.md
+++ b/content/resources.md
@@ -2,55 +2,6 @@
 title: "Resources"
 ---
 
-## Index
-
-* [Blogs](#blogs)
-* [Talks](#talks)
-* [Podcasts](#podcasts)
-* [Meetups](meetups)
-* [Documentation](#documentation)
-* [Whitepapers](#whitepapers)
-* [Libraries and ORMs](#libraries)
-* [Tools](#tools)
-* [Configuration management](#configuration)
-* [Migration](#migration)
-* [Performance and debugging](#performance)
-
-## Blogs {#blogs}
-
-### Technical overview
-
-* Apr 2020: [Things I Wished More Developers Knew About Databases](https://medium.com/@rakyll/things-i-wished-more-developers-knew-about-databases-2d0178464f78)
-
-### Operational excellence
-
-* Jul 2020: [Cloud Spanner Change Watcher](https://medium.com/@knutolavloite/cloud-spanner-change-watcher-b77ca036459c) and [Cloud Spanner Change Publisher](https://medium.com/@knutolavloite/cloud-spanner-change-publisher-7fbee48f66f8)
-* May 2020: [Create Cloud Spanner Scheduled Backups](https://medium.com/@hengfeng/create-cloud-spanner-scheduled-backups-c6f30551a6fd)
-* Apr 2020: [Instrumenting Cloud Spanner Go Applications with OpenCensus](https://medium.com/google-cloud/instrumenting-cloud-spanner-go-applications-with-opencensus-6e734eb4d8c8)
-* Mar 2020: [Troubleshooting Cloud Spanner Applications with OpenCensus](https://medium.com/@mayurkale22/troubleshooting-cloud-spanner-applications-with-opencensus-2cf424c4c590)
-
-### Internals
-
-* May 2020: [How Does Spanner Avoid Single Point of Failures in Writes?](https://medium.com/google-cloud/how-does-spanner-avoid-single-point-of-failures-in-writes-4f7765cd894)
-* Feb 2020: [Internals of Google Cloud Spanner](https://medium.com/searce/internals-of-google-cloud-spanner-5927e4b83b36)
-
-### Performance
-
-* Jun 2020: [Increase visibility into Cloud Spanner performance with transaction stats](https://cloud.google.com/blog/products/databases/database-transaction-stats-in-spanner)
-* May 2020: [Use GFE Server-Timing Header in Cloud Spanner Debugging](https://medium.com/google-cloud/use-gfe-server-timing-header-in-cloud-spanner-debugging-d7d891a50642)
-
-### Developer productivity
-
-* Jun 2020: [DML and Mutations - a tale of two data altering techniques in Cloud Spanner](https://medium.com/google-cloud/dml-and-mutations-a-tale-of-two-data-altering-techniques-in-cloud-spanner-df13c49f2617)
-* Apr 2020: [Cloud Spanner Emulator](https://medium.com/google-cloud/cloud-spanner-emulator-bf12d141c12)
-* Dec 2019: [Google Cloud Spanner Dialect for Hibernate released](https://in.relation.to/2019/12/18/google-cloud-spanner-dialect/)
-* Nov 2019: [Opening the door to more dev tools for Cloud Spanner](https://cloud.google.com/blog/products/databases/opening-the-door-to-more-dev-tools-for-cloud-spanner)
-
-### Migration
-
-* Feb 2020: [HarbourBridge: From PostgreSQL to Cloud Spanner](https://opensource.googleblog.com/2020/02/harbourbridge-from-postgresql-to-cloud.html)
-* Jun 2019: [Migrating from DynamoDB to Google Cloud Spanner](https://medium.com/petabytz/database-migration-migrating-from-dynamodb-to-google-cloud-spanner-part-1-ab6b8828580d)
-
 ## Talks {#talks}
 
 * [Cloud Spanner 101: Google's mission-critical relational database](https://www.youtube.com/watch?v=IfsTINNCooY)
@@ -82,6 +33,7 @@ title: "Resources"
 * [Spanner, TrueTime and the CAP Theorem](https://research.google/pubs/pub45855/)
 * [Spanner: Becoming a SQL System](https://research.google/pubs/pub46103/)
 
+
 ## Libraries and ORMs {#libraries}
 
 ### Client libraries
@@ -102,7 +54,7 @@ title: "Resources"
 * [R2DBC](https://github.com/GoogleCloudPlatform/cloud-spanner-r2dbc) driver
 * [Go database/sql](https://github.com/rakyll/go-sql-driver-spanner) driver
 
-### ORM
+### ORMs
 
 * [Django](https://github.com/googleapis/python-spanner-django/)
 * [Hibernate ORM](https://cloud.google.com/spanner/docs/use-hibernate)
@@ -141,4 +93,3 @@ title: "Resources"
 * [CPU Utilization](https://cloud.google.com/spanner/docs/cpu-utilization)
 * [Latency Debugging](https://cloud.google.com/spanner/docs/latency)
 * [Distributed Tracing and Client Metrics](https://medium.com/@orijtech/cloud-spanner-instrumented-by-opencensus-and-exported-to-stackdriver-6ed61ed6ab4e)
-

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -6,8 +6,8 @@
   <ul>
     <li><a href="/">Home</a></li>
     <li><a href="/projects/">Projects</a></li>
+    <li><a href="/blog/">Blog</a></li>
     <li><a href="/resources/">Resources</a></li>
-    <li><a href="/contributing/">Contributing</a></li>
     <li><a href="https://gitter.im/cloudspannerecosystem/community">Gitter</a></li>
     <li><a href="https://github.com/cloudspannerecosystem">GitHub</a></li>
   </ul>


### PR DESCRIPTION
Also removed the ToC from resources page because the page got slightly smaller and a table of contents is not significantly improving the navigation but polluting the page. If we can introduce a different CSS style for ToCs, it might be useful to bring it back.