### PR TITLE
Updating support statement to say that it support is on a per project basis

### DIFF
--- a/content/home.md
+++ b/content/home.md
@@ -12,8 +12,9 @@ user community.
 All the hosted projects are based on open source contributions.
 We’d love for you to report issues, file feature requests,
 and send pull requests (see [contributions](/contributing)).
-Note that none of the projects are officially supported by Google
-as part of the Cloud Spanner product.
+Note that none of the projects are officially supported by Google as
+part of the Cloud Spanner product, unless explicitly stated otherwise
+in that project’s README.
 
 Please [let us know](https://gitter.im/cloudspannerecosystem/community)
 if you’re interested in getting your project hosted! This will help other


### PR DESCRIPTION
This updates the support statement to communicate that support is provided or not on a per project basis.  This change is being made in conjunction with an update to the support statement for the Autoscaler project.